### PR TITLE
Remove gitlab social from configuration

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -74,7 +74,6 @@
   ],
   "footerSocials": {
     "github": "https://github.com/amplify-security",
-    "gitlab": "https://gitlab.com/amplify-security",
     "linkedin": "https://www.linkedin.com/company/amplify-security/"
   }
 }


### PR DESCRIPTION
According to docs (and archived versions of the page) there has been a list of accepted socials for a long time which never had gitlab in it, but it looks like it only recently started getting validated/enforced during deploys
